### PR TITLE
Update releases link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Miniature](https://i.imgur.com/AM7V5kL.png)
-**[Download Miniature Alpha](github.com/doreminiature/miniature/releases/tag/v0.1-alpha)**.
+**[Download Miniature Alpha](https://github.com/doreminiature/miniature/releases/tag/v0.1-alpha)**.
 
 4.6 bn web pages!
 ------


### PR DESCRIPTION
Missing scheme made it go 404 (base URL + linked URL)